### PR TITLE
Removed unused annotations

### DIFF
--- a/src/main/java/com/ukolpakova/soap/controller/RatesController.java
+++ b/src/main/java/com/ukolpakova/soap/controller/RatesController.java
@@ -2,7 +2,6 @@ package com.ukolpakova.soap.controller;
 
 import com.ukolpakova.soap.response.CurrencyRatesResponse;
 import com.ukolpakova.soap.service.RatesService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +17,6 @@ public class RatesController {
 
     private final RatesService ratesService;
 
-    @Autowired
     public RatesController(RatesService ratesService) {
         this.ratesService = ratesService;
     }

--- a/src/main/java/com/ukolpakova/soap/service/RatesService.java
+++ b/src/main/java/com/ukolpakova/soap/service/RatesService.java
@@ -14,7 +14,6 @@ import com.ukolpakova.soap.wsclient.generated.GetCurrentFxRatesResponse;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -38,7 +37,6 @@ public class RatesService {
 
     private FxRatesSoap fxRatesSoap;
 
-    @Autowired
     public RatesService(CurrencyParser currencyParser, CurrencyRatesParser currencyRatesParser) {
         this.currencyParser = currencyParser;
         this.currencyRatesParser = currencyRatesParser;


### PR DESCRIPTION
From Spring Framework v4.3 it's not obligatory to annotate the constructor if this constructor is only one in the class (JSR 330).